### PR TITLE
add call to get our own profile

### DIFF
--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
@@ -96,3 +96,41 @@ class UsersIdTests(APITestCase):
 
         # Check the status code
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve_profile(self):
+        """
+        Ensure we can retrieve our profile without id.
+        """
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(
+            reverse(
+                'profile',
+            )
+        )
+
+        content = json.loads(response.content)
+
+        # Check id of the user
+        self.assertEqual(content['id'], 1)
+
+        # Check the system doesn't return attributes not expected
+        attributes = ['id', 'username', 'email', 'first_name',
+                      'last_name', 'is_active']
+        for key in content.keys():
+            self.assertTrue(
+                key in attributes,
+                'Attribute "{0}" is not expected but is '
+                'returned by the system.'.format(key)
+            )
+            attributes.remove(key)
+
+        # Ensure the system returns all expected attributes
+        self.assertTrue(
+            len(attributes) == 0,
+            'The system failed to return some '
+            'attributes : {0}'.format(attributes)
+        )
+
+        # Check the status code
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/source/apiVolontaria/apiVolontaria/urls.py
+++ b/source/apiVolontaria/apiVolontaria/urls.py
@@ -41,6 +41,14 @@ urlpatterns = [
         UsersId.as_view(),
         name='users_id',
     ),
+    url(
+        r'^profile$',
+        UsersId.as_view(),
+        kwargs=dict(
+            profile=True,
+        ),
+        name='profile',
+    ),
     # Volunteer
     url(
         r'^volunteer/',

--- a/source/apiVolontaria/apiVolontaria/views.py
+++ b/source/apiVolontaria/apiVolontaria/views.py
@@ -127,7 +127,11 @@ class UsersId(generics.RetrieveAPIView):
         return User.objects.filter()
 
     def get(self, request, *args, **kwargs):
-        if self.request.user.has_perm('apiVolontaria.get_user'):
+        if 'profile' in self.kwargs.keys():
+            self.kwargs['pk'] = self.request.user.id
+            return self.retrieve(request, *args, **kwargs)
+
+        elif self.request.user.has_perm('apiVolontaria.get_user'):
             return self.retrieve(request, *args, **kwargs)
 
         content = {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Features
| Tickets (_issues_) concerned               | #54 

---

##### What have you changed ?
Allow user to get his personnal profile

##### How did you change it ?
Add an url `/profile`
Refactor `UsersId` view to manage profile without `lookup_field`

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
