### PR TITLE
Fix user POSTing password hash

### DIFF
--- a/source/apiVolontaria/apiVolontaria/serializers.py
+++ b/source/apiVolontaria/apiVolontaria/serializers.py
@@ -96,6 +96,9 @@ class UserBasicSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         user = User(**validated_data)
 
+        # Hash the user's password
+        user.set_password(validated_data['password'])
+
         # Put user inactive by default
         user.is_active = False
         user.save()

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
@@ -45,6 +45,7 @@ class UsersTests(APITestCase):
         activation_token = ActivationToken.objects.filter(user=user)
 
         self.assertEqual(1, len(activation_token))
+        self.assertTrue(user.check_password(data['password']))
 
     def test_create_new_user_without_username(self):
         """


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | fixed #63 

---

##### What have you changed ?
Added password hashing on user POSTing.

##### How did you change it ?
Added `user.set_password(validated_data['password'])` in the `create()` function of the User serializer.

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
