### PR TITLE
Enhancement event volunteer count

### DIFF
--- a/source/apiVolontaria/volunteer/models.py
+++ b/source/apiVolontaria/volunteer/models.py
@@ -193,6 +193,14 @@ class Event(models.Model):
     def is_active(self):
         return self.cycle.is_active
 
+    @property
+    def nb_volunteers(self):
+        return self.volunteers.filter(participation__standby=False).count()
+
+    @property
+    def nb_volunteers_standby(self):
+        return self.volunteers.filter(participation__standby=True).count()
+
 
 class Participation(models.Model):
     """

--- a/source/apiVolontaria/volunteer/serializers.py
+++ b/source/apiVolontaria/volunteer/serializers.py
@@ -216,7 +216,9 @@ class EventBasicSerializer(serializers.ModelSerializer):
             'start_date',
             'end_date',
             'nb_volunteers_needed',
+            'nb_volunteers',
             'nb_volunteers_standby_needed',
+            'nb_volunteers_standby',
             'volunteers',
             'cell',
             'cycle',
@@ -228,6 +230,8 @@ class EventBasicSerializer(serializers.ModelSerializer):
         read_only_fields = [
             'id',
             'subscription_date',
+            'nb_volunteers',
+            'nb_volunteers_standby',
         ]
 
 

--- a/source/apiVolontaria/volunteer/tests/tests_model_Event.py
+++ b/source/apiVolontaria/volunteer/tests/tests_model_Event.py
@@ -17,6 +17,10 @@ class EventTests(APITransactionTestCase):
         self.user.set_password('Test123!')
         self.user.save()
 
+        self.user2 = UserFactory()
+        self.user2.set_password('Test123!')
+        self.user2.save()
+
         self.admin = AdminFactory()
         self.admin.set_password('Test123!')
         self.admin.save()
@@ -342,9 +346,21 @@ class EventTests(APITransactionTestCase):
             end_date=end_date,
         )
 
-        participation = Participation.objects.create(
-            standby=False,
+        Participation.objects.create(
+            standby=True,
             user=self.user,
+            event=event,
+        )
+
+        Participation.objects.create(
+            standby=True,
+            user=self.user2,
+            event=event,
+        )
+
+        Participation.objects.create(
+            standby=False,
+            user=self.admin,
             event=event,
         )
 
@@ -372,10 +388,22 @@ class EventTests(APITransactionTestCase):
             end_date=end_date,
         )
 
-        participation = Participation.objects.create(
+        Participation.objects.create(
             standby=True,
             user=self.user,
             event=event,
         )
 
-        self.assertEqual(event.nb_volunteers_standby, 1)
+        Participation.objects.create(
+            standby=True,
+            user=self.user2,
+            event=event,
+        )
+
+        Participation.objects.create(
+            standby=False,
+            user=self.admin,
+            event=event,
+        )
+
+        self.assertEqual(event.nb_volunteers_standby, 2)

--- a/source/apiVolontaria/volunteer/tests/tests_model_Event.py
+++ b/source/apiVolontaria/volunteer/tests/tests_model_Event.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from apiVolontaria.factories import UserFactory, AdminFactory
 from location.models import Address, StateProvince, Country
-from ..models import Cell, TaskType, Cycle, Event
+from ..models import Cell, TaskType, Cycle, Event, Participation
 
 
 class EventTests(APITransactionTestCase):
@@ -320,3 +320,62 @@ class EventTests(APITransactionTestCase):
             end_date=end_date,
             task_type=self.task_type,
         )
+
+    def test_nb_volunteers_property(self):
+        """
+        Ensure we get the correct number of volunteers that are signed up
+        """
+        start_date = timezone.now()
+        end_date = start_date
+
+        cycle = Cycle.objects.create(
+            name="my cycle",
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        event = Event.objects.create(
+            cell=self.cell,
+            cycle=cycle,
+            task_type=self.task_type,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        participation = Participation.objects.create(
+            standby=False,
+            user=self.user,
+            event=event,
+        )
+
+        self.assertEqual(event.nb_volunteers, 1)
+
+    def test_nb_volunteers_standby_property(self):
+        """
+        Ensure we get the correct number of volunteers that are signed up and
+        on hold.
+        """
+        start_date = timezone.now()
+        end_date = start_date
+
+        cycle = Cycle.objects.create(
+            name="my cycle",
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        event = Event.objects.create(
+            cell=self.cell,
+            cycle=cycle,
+            task_type=self.task_type,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        participation = Participation.objects.create(
+            standby=True,
+            user=self.user,
+            event=event,
+        )
+
+        self.assertEqual(event.nb_volunteers_standby, 1)

--- a/source/apiVolontaria/volunteer/tests/tests_view_Events.py
+++ b/source/apiVolontaria/volunteer/tests/tests_view_Events.py
@@ -125,11 +125,14 @@ class EventsTests(APITestCase):
         self.assertEqual(content['task_type']['id'], self.task_type.id)
         self.assertEqual(content['nb_volunteers_needed'], 0)
         self.assertEqual(content['nb_volunteers_standby_needed'], 0)
+        self.assertEqual(content['nb_volunteers'], 0)
+        self.assertEqual(content['nb_volunteers_standby'], 0)
 
         # Check the system doesn't return attributes not expected
         attributes = ['id', 'start_date', 'end_date', 'nb_volunteers_needed',
                       'nb_volunteers_standby_needed', 'volunteers', 'cell',
-                      'cycle', 'task_type']
+                      'cycle', 'task_type', 'nb_volunteers_standby',
+                      'nb_volunteers']
 
         for key in content.keys():
             self.assertTrue(
@@ -194,7 +197,8 @@ class EventsTests(APITestCase):
         # Check the system doesn't return attributes not expected
         attributes = ['id', 'start_date', 'end_date', 'nb_volunteers_needed',
                       'nb_volunteers_standby_needed', 'volunteers', 'cell',
-                      'cycle', 'task_type']
+                      'cycle', 'task_type', 'nb_volunteers_standby',
+                      'nb_volunteers']
 
         for key in content['results'][0].keys():
             self.assertTrue(
@@ -230,7 +234,8 @@ class EventsTests(APITestCase):
         # Check the system doesn't return attributes not expected
         attributes = ['id', 'start_date', 'end_date', 'nb_volunteers_needed',
                       'nb_volunteers_standby_needed', 'volunteers', 'cell',
-                      'cycle', 'task_type']
+                      'cycle', 'task_type', 'nb_volunteers_standby',
+                      'nb_volunteers']
 
         for key in content['results'][0].keys():
             self.assertTrue(

--- a/source/apiVolontaria/volunteer/tests/tests_view_EventsId.py
+++ b/source/apiVolontaria/volunteer/tests/tests_view_EventsId.py
@@ -119,6 +119,14 @@ class EventsIdTests(APITestCase):
             result['nb_volunteers_standby_needed'],
             self.event.nb_volunteers_standby_needed
         )
+        self.assertEqual(
+            result['nb_volunteers'],
+            self.event.nb_volunteers
+        )
+        self.assertEqual(
+            result['nb_volunteers_standby'],
+            self.event.nb_volunteers_standby
+        )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -163,6 +171,14 @@ class EventsIdTests(APITestCase):
         self.assertEqual(
             result['nb_volunteers_standby_needed'],
             self.event.nb_volunteers_standby_needed,
+        )
+        self.assertEqual(
+            result['nb_volunteers'],
+            self.event.nb_volunteers
+        )
+        self.assertEqual(
+            result['nb_volunteers_standby'],
+            self.event.nb_volunteers_standby
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | Closes #71 

---

##### What have you changed ?
This PR enables the user to get the number of volunteers subscribed to events.

##### How did you change it ?
- Two new model properties are added to the "Event" model: `nb_volunteer` and `nb_volunteer_standby`. Those properties return an integer representing a number of users.
> event.nb_volunteer = number of volunteers that will attend the event.
event.nb_volunteer_Standby = number of volunteers that are on hold for the event.

- The Event serializer now adds those 2 read-only fields when representing the object.

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
