### PR TITLE
Add email service integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ drfdocs==0.0.11
 django-cors-headers==2.0.2
 Faker==0.8.6
 factory-boy==2.9.2
+imailing==0.1

--- a/source/apiVolontaria/apiVolontaria/settings.py
+++ b/source/apiVolontaria/apiVolontaria/settings.py
@@ -174,6 +174,30 @@ ACTIVATION_TOKENS = {
     'MINUTES': 2880,
 }
 
+# These settings are not related to the core API functionality. Feel free to
+# edit them to your needs.
+# NOTE: "{{token}}" is a placeholder for the real activation token. It will be
+#       dynamically replaced by the real "token".
+CONSTANT = {
+    "EMAIL_SERVICE": False,
+    "AUTO_ACTIVATE_USER": False,
+    "FRONTEND_INTEGRATION": {
+        "ACTIVATION_URL": "example.com/activate?activation_token={{token}}",
+    },
+}
+
+# Email service configuration.
+# Supported services: SendinBlue.
+SETTINGS_IMAILING = {
+    "SERVICE": "SendinBlue",
+    "API_KEY": "example_api_key",
+    "EMAIL_FROM": "admin@example.com",
+    "TEMPLATES": {
+        "CONFIRM_SIGN_UP": "example_template_id"
+    }
+}
+
+
 try:
     from apiVolontaria.local_settings import *
 except ImportError:


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Features
| Tickets (_issues_) concerned               | Closes #44 

This PR replaces PR #52 (some changes are added)

---

##### What have you changed ?
Add the possibility to automatically send confirmation emails (using SendinBlue) to user when they sign up. These emails can contain a link to activate their account. 

##### How did you change it ?
- Added settings in `settings.py` to configure the email service.
- Updated /users POST view to send emails if the service is configured and keep the subscribing user inactive.


Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
