### PR TITLE
Fix password complexity validation on user create

### DIFF
--- a/source/apiVolontaria/apiVolontaria/serializers.py
+++ b/source/apiVolontaria/apiVolontaria/serializers.py
@@ -94,6 +94,15 @@ class UserBasicSerializer(serializers.ModelSerializer):
     )
 
     def create(self, validated_data):
+        try:
+            password_validation.validate_password(
+                password=validated_data['password']
+            )
+        except ValidationError as err:
+            raise serializers.ValidationError({
+                "password": err.messages
+                })
+
         profile_data = None
         if 'profile' in validated_data.keys():
             profile_data = validated_data.pop('profile')
@@ -133,7 +142,9 @@ class UserBasicSerializer(serializers.ModelSerializer):
                 try:
                     password_validation.validate_password(password=new_pw)
                 except ValidationError as err:
-                    raise serializers.ValidationError(err.messages)
+                    raise serializers.ValidationError({
+                        "password": err.messages
+                        })
                 instance.set_password(new_pw)
             else:
                 msg = "Bad password"

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
@@ -135,6 +135,27 @@ class UsersTests(APITestCase):
         content = {"password": ["This field is required."]}
         self.assertEqual(json.loads(response.content), content)
 
+    def test_create_new_user_weak_password(self):
+        """
+        Ensure we can't create a new user with a weak password
+        """
+        data = {
+            'username': 'John',
+            'email': 'John@mailinator.com',
+            'password': '19274682736',
+        }
+
+        response = self.client.post(
+            reverse('users'),
+            data,
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        content = {"password": ['This password is entirely numeric.']}
+        self.assertEqual(json.loads(response.content), content)
+
     def test_create_new_user_duplicate_email(self):
         """
         Ensure we can't create a new user with an already existing email

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
@@ -312,7 +312,7 @@ class UsersIdTests(APITestCase):
             format='json',
         )
 
-        content = ['This password is entirely numeric.']
+        content = {'password': ['This password is entirely numeric.']}
         self.assertEqual(json.loads(response.content), content)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | none

---

##### What have you changed ?
Added a password validation when a user registers.

##### How did you change it ?
In the user serializer, added the default password validation of django.

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
