### PR TITLE
add constraint on participation deletion

### DIFF
--- a/source/apiVolontaria/volunteer/models.py
+++ b/source/apiVolontaria/volunteer/models.py
@@ -190,6 +190,10 @@ class Event(models.Model):
         )
 
     @property
+    def is_started(self):
+        return self.start_date <= timezone.now()
+
+    @property
     def is_expired(self):
         return self.end_date <= timezone.now()
 

--- a/source/apiVolontaria/volunteer/tests/tests_model_Event.py
+++ b/source/apiVolontaria/volunteer/tests/tests_model_Event.py
@@ -407,3 +407,43 @@ class EventTests(APITransactionTestCase):
         )
 
         self.assertEqual(event.nb_volunteers_standby, 2)
+
+    def test_is_started_property_false(self):
+        """
+        Ensure we have False if the event is not started
+        """
+        start_date = timezone.now() + timezone.timedelta(
+            minutes=100
+        )
+        end_date = start_date + timezone.timedelta(
+            minutes=100
+        )
+
+        event = Event.objects.create(
+            cell=self.cell,
+            cycle=self.cycle,
+            task_type=self.task_type,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        self.assertEqual(event.is_started, False)
+
+    def test_is_started_property_true(self):
+        """
+        Ensure we have True if the event is started
+        """
+        start_date = timezone.now()
+        end_date = start_date + timezone.timedelta(
+            minutes=100
+        )
+
+        event = Event.objects.create(
+            cell=self.cell,
+            cycle=self.cycle,
+            task_type=self.task_type,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        self.assertEqual(event.is_started, True)

--- a/source/apiVolontaria/volunteer/views.py
+++ b/source/apiVolontaria/volunteer/views.py
@@ -6,6 +6,8 @@ from rest_framework.permissions import IsAuthenticated
 from .permissions import IsOwnerOrReadOnly
 from . import models, serializers
 
+from django.utils.translation import ugettext_lazy as _
+
 
 class Cycles(generics.ListCreateAPIView):
     """
@@ -339,3 +341,15 @@ class ParticipationsId(generics.RetrieveUpdateDestroyAPIView):
 
     def get_queryset(self):
         return models.Participation.objects.filter()
+
+    def delete(self, request, *args, **kwargs):
+        participation = self.get_object()
+        if not participation.event.is_started:
+            return self.destroy(request, *args, **kwargs)
+        else:
+            content = {
+                'detail': _("You can't delete a participation if the "
+                            "associated event is already started"),
+            }
+
+            return Response(content, status=status.HTTP_403_FORBIDDEN)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | fixed #84 

---

##### What have you changed ?
Add a new condition to forbid user delete participation when the associated event is already started

##### How did you change it ?
 - Overwrite the `delete()` method of the `Participation` model
 - Create a new type of `Exception` named `BusinessException`
 - Overwrite the `delete()` method of the view `ParticipationsId` to manage this new Exception

**Special consideration**

 - Serializer not take in charge the deletion of object, they only manage creation and update. It's why i've refactor the view in place of the serializer.

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
