### PR TITLE
add is_active column on user admin panel

### DIFF
--- a/source/apiVolontaria/apiVolontaria/admin.py
+++ b/source/apiVolontaria/apiVolontaria/admin.py
@@ -1,5 +1,27 @@
 from django.contrib import admin
+from django.contrib.auth.models import User
+
 from . import models
+
+
+class UserAdmin(admin.ModelAdmin):
+    list_display = [
+        'username',
+        'email',
+        'first_name',
+        'last_name',
+        'is_active',
+        'is_staff'
+    ]
+
+    list_filter = [
+        'is_staff',
+        'is_superuser',
+        'is_active',
+    ]
+
 
 admin.site.register(models.TemporaryToken)
 admin.site.register(models.Profile)
+admin.site.unregister(User)
+admin.site.register(User, UserAdmin)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | fixed #95 

---

##### What have you changed ?
Add `is_active` column in the admin panel's user page

##### How did you change it ?
 - Unregister the user default admin panel configuration
 - Register a custom user admin panel

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests

---
![screenshot-2018-1-28 select user to change django site admin](https://user-images.githubusercontent.com/12053720/35486170-491981a0-0438-11e8-907d-fcb5e5b799e2.png)
