### PR TITLE
[WIP] Send email on participation creation

### DIFF
--- a/source/apiVolontaria/apiVolontaria/settings.py
+++ b/source/apiVolontaria/apiVolontaria/settings.py
@@ -181,6 +181,7 @@ ACTIVATION_TOKENS = {
 CONSTANT = {
     "EMAIL_SERVICE": False,
     "AUTO_ACTIVATE_USER": False,
+    "SEND_EMAIL_CONFIRM_CREATE_PARTICIPATION": False,
     "FRONTEND_INTEGRATION": {
         "ACTIVATION_URL": "example.com/activate?activation_token={{token}}",
     },
@@ -193,7 +194,8 @@ SETTINGS_IMAILING = {
     "API_KEY": "example_api_key",
     "EMAIL_FROM": "admin@example.com",
     "TEMPLATES": {
-        "CONFIRM_SIGN_UP": "example_template_id"
+        "CONFIRM_SIGN_UP": "example_template_id",
+        "CONFIRM_CREATE_PARTICIPATION": "example_template_id",
     }
 }
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | fixed #93 

---

##### What have you changed ?
Send an email when user create a new participation

##### How did you change it ?
 - Add a new template in the settings
 - Add a new variable in settings to allow or not the email of confirmation on participation creation
 - Refactor the participation creation view to add new logic

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
