### PR TITLE
Add a setting to hide the live API in production

### DIFF
--- a/source/apiVolontaria/apiVolontaria/settings.py
+++ b/source/apiVolontaria/apiVolontaria/settings.py
@@ -159,6 +159,12 @@ REST_FRAMEWORK = {
 
 CORS_ORIGIN_ALLOW_ALL = True
 
+# Rest framework docs (live API) settings
+
+REST_FRAMEWORK_DOCS = {
+    'HIDE_DOCS': True
+}
+
 
 # Temporary Token
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | none

---

##### What have you changed ?
This PR adds a way to easily disable the live API.

##### How did you change it ?
New setting in `settings.py`:
```
# Rest framework docs (live API) settings

REST_FRAMEWORK_DOCS = {
    'HIDE_DOCS': True
}
```

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] (no tests) I added or modified the attached tests
