### PR TITLE
[Missing test] Activate DRF's translations

### DIFF
--- a/source/apiVolontaria/apiVolontaria/settings.py
+++ b/source/apiVolontaria/apiVolontaria/settings.py
@@ -55,6 +55,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
 ]
 
 ROOT_URLCONF = 'apiVolontaria.urls'


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | #72 (partial)

---

##### What have you changed ?
This PR activates DRF's default translation engine. It will automatically translate most* error messages by checking the `Accept-language` header of each request.

*This adds translation capability of **default** error messages included in DRF. Custom errors will need to be manually translated or switched to a default messages.

##### How did you change it ?
Added middleware `django.middleware.locale.LocaleMiddleware` to `settings.py`.

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
