### PR TITLE
allow search user by username, first_name, email and last_name

### DIFF
--- a/source/apiVolontaria/apiVolontaria/admin.py
+++ b/source/apiVolontaria/apiVolontaria/admin.py
@@ -20,6 +20,13 @@ class UserAdmin(admin.ModelAdmin):
         'is_active',
     ]
 
+    search_fields = [
+        'username',
+        'first_name',
+        'last_name',
+        'email',
+    ]
+
 
 admin.site.register(models.TemporaryToken)
 admin.site.register(models.Profile)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | None

> [...] Les autres demandes urgentes de Valérie ce matin : pourvoir trouver dans l’admin les utilisateurs par leur nom, prenom ou courriel [...]. 

@yanicolivier on Slack

---

##### What have you changed ?
Allow staff to search user by `first_name`, `last_name` and/or `username` in the admin panel

##### How did you change it ?
Just add a `search_fields` in the `ModelAdmin`

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests

---

![screenshot-2018-2-7 select user to change django site admin](https://user-images.githubusercontent.com/12053720/35941622-e3b64578-0c20-11e8-80cf-e39cc3e69fb8.png)
