### PR TITLE
fix password input and add profil inline

### DIFF
--- a/source/apiVolontaria/apiVolontaria/admin.py
+++ b/source/apiVolontaria/apiVolontaria/admin.py
@@ -1,17 +1,27 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
+from django.contrib.auth.admin import UserAdmin
 
 from . import models
 
 
-class UserAdmin(admin.ModelAdmin):
+class ProfileInline(admin.StackedInline):
+    model = models.Profile
+    can_delete = False
+    verbose_name_plural = 'Profile'
+    fk_name = 'user'
+
+
+class CustomUserAdmin(UserAdmin):
     list_display = [
         'username',
         'email',
         'first_name',
         'last_name',
+        'get_mobile',
+        'get_phone',
         'is_active',
-        'is_staff'
+        'is_staff',
     ]
 
     list_filter = [
@@ -27,8 +37,17 @@ class UserAdmin(admin.ModelAdmin):
         'email',
     ]
 
+    inlines = (ProfileInline, )
+
+    def get_mobile(self, instance):
+        return instance.profile.mobile
+    get_mobile.short_description = 'Mobile'
+
+    def get_phone(self, instance):
+        return instance.profile.phone
+    get_phone.short_description = 'Phone'
+
 
 admin.site.register(models.TemporaryToken)
-admin.site.register(models.Profile)
 admin.site.unregister(User)
-admin.site.register(User, UserAdmin)
+admin.site.register(User, CustomUserAdmin)

--- a/source/apiVolontaria/apiVolontaria/tests/tests_admin_User.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_admin_User.py
@@ -1,0 +1,61 @@
+from rest_framework.test import APIClient
+
+from rest_framework.test import APITestCase
+
+from apiVolontaria.models import TemporaryToken
+from apiVolontaria.factories import UserFactory
+from django.utils import timezone
+
+
+class TemporaryTokenTests(APITestCase):
+
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_expired_property_false(self):
+        """
+        Ensure that expired() returns False when the token is not expired
+        """
+        token = TemporaryToken.objects.create(
+            user=self.user
+        )
+
+        token.expires = timezone.now() + timezone.timedelta(
+            minutes=100
+        )
+
+        self.assertEquals(token.expired, False)
+
+    def test_expired_property_true(self):
+        """
+        Ensure that expired() returns True when the token is expired
+        """
+        token = TemporaryToken.objects.create(
+            user=self.user
+        )
+
+        token.expires = timezone.now() - timezone.timedelta(seconds=1)
+
+        # It's already not equal because time is
+        # passed since the last line of code
+        self.assertEquals(True, token.expired)
+
+    def test_expire_function_true(self):
+        """
+        Ensure that expire() sets the token as "expired"
+        """
+        token = TemporaryToken.objects.create(
+            user=self.user
+        )
+
+        token.expires = timezone.now() + timezone.timedelta(
+            minutes=100
+        )
+
+        # The token is not expired, 100 minutes remain
+        self.assertEquals(False, token.expired)
+
+        token.expire()
+
+        # The token is expired because we ask for
+        self.assertEquals(True, token.expired)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | fixed #130 

---

##### What have you changed ?
 - Fix the user's password input in the admin panel
 - Add the profile in the user detail page of the admin panel

##### How did you change it ?
Refactor `ApiVolontaria/admin.py` to :
 - Ovrewrite default user's admin panel
 - Add an Inline
 - Add `mobile` and `phone` of profile in the user list

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests


---
## Screenshots

**New inline profile in the user's detail page:**
![screenshot-2018-2-16 change user django site admin 1](https://user-images.githubusercontent.com/12053720/36318078-cda01636-130c-11e8-8e84-8e855092970e.png)

---

**New listings of user in the admin panel:**
![screenshot-2018-2-16 select user to change django site admin](https://user-images.githubusercontent.com/12053720/36318079-cdb3d6b2-130c-11e8-8c9c-758d371f08f8.png)

---

**Fix password input:**
![screenshot-2018-2-16 change user django site admin 2](https://user-images.githubusercontent.com/12053720/36318102-e165c990-130c-11e8-811b-1a580c1da75e.png)

