### PR TITLE
Fix 132 add issuperuser fields

### DIFF
--- a/source/apiVolontaria/apiVolontaria/serializers.py
+++ b/source/apiVolontaria/apiVolontaria/serializers.py
@@ -65,6 +65,7 @@ class UserBasicSerializer(serializers.ModelSerializer):
             'first_name',
             'last_name',
             'is_active',
+            'is_superuser',
             'password',
             'new_password',
             'phone',

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
@@ -365,8 +365,17 @@ class UsersTests(APITestCase):
         self.assertEqual(first_user['id'], self.user.id)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'username', 'email', 'first_name',
-                      'last_name', 'is_active', 'phone', 'mobile']
+        attributes = [
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'phone',
+            'mobile',
+            'is_superuser',
+        ]
         for key in first_user.keys():
             self.assertTrue(
                 key in attributes,

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
@@ -78,8 +78,17 @@ class UsersIdTests(APITestCase):
         self.assertEqual(content['id'], 1)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'username', 'email', 'first_name',
-                      'last_name', 'is_active', 'phone', 'mobile']
+        attributes = [
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'phone',
+            'mobile',
+            'is_superuser',
+        ]
         for key in content.keys():
             self.assertTrue(
                 key in attributes,
@@ -116,8 +125,17 @@ class UsersIdTests(APITestCase):
         self.assertEqual(content['id'], 1)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'username', 'email', 'first_name',
-                      'last_name', 'is_active', 'phone', 'mobile']
+        attributes = [
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'phone',
+            'mobile',
+            'is_superuser',
+        ]
         for key in content.keys():
             self.assertTrue(
                 key in attributes,
@@ -165,8 +183,17 @@ class UsersIdTests(APITestCase):
         self.assertEqual(content['id'], 1)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'username', 'email', 'first_name',
-                      'last_name', 'is_active', 'phone', 'mobile']
+        attributes = [
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'phone',
+            'mobile',
+            'is_superuser',
+        ]
         for key in content.keys():
             self.assertTrue(
                 key in attributes,
@@ -245,8 +272,17 @@ class UsersIdTests(APITestCase):
         self.assertEqual(content['id'], 1)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'username', 'email', 'first_name',
-                      'last_name', 'is_active', 'phone', 'mobile']
+        attributes = [
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'phone',
+            'mobile',
+            'is_superuser',
+        ]
         for key in content.keys():
             self.assertTrue(
                 key in attributes,


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | fixed #132 

---

##### What have you changed ?
Allow users to know if a user is superadmin or not

##### How did you change it ?
Add `is_superuser` field in the user serializer

Verification :
 -  [x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [x] This Pull-Request fully meets the requirements defined in the issue
 -  [x] I added or modified the attached tests
