### PR TITLE
Enhancement allow user to get only active cycles

### DIFF
--- a/source/apiVolontaria/volunteer/managers.py
+++ b/source/apiVolontaria/volunteer/managers.py
@@ -1,0 +1,28 @@
+from django.db import models
+
+
+class CycleManager(models.Manager):
+    """
+    Custom manager for Cycle model
+
+    This custom manager allow us to use property
+    directly in the filter request
+    """
+    def filter(self, is_active=None, *args, **kwargs):
+        filtered_cycle = super(
+            CycleManager,
+            self
+        ).filter(*args, **kwargs)
+
+        if is_active is not None:
+            list_exclude = list()
+
+            for cycle in filtered_cycle:
+                if cycle.is_active != is_active:
+                    list_exclude.append(cycle)
+
+            filtered_cycle = filtered_cycle.exclude(
+                pk__in=[cycle.pk for cycle in list_exclude]
+            )
+
+        return filtered_cycle

--- a/source/apiVolontaria/volunteer/models.py
+++ b/source/apiVolontaria/volunteer/models.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
-from decimal import Decimal
+
 from django.contrib.auth.models import User
 from django.db import models, IntegrityError
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from location.models import Address
+
+from .managers import CycleManager
 
 
 class Cycle(models.Model):
@@ -31,6 +33,8 @@ class Cycle(models.Model):
         blank=True,
         null=True
     )
+
+    objects = CycleManager()
 
     @property
     def is_active(self):

--- a/source/apiVolontaria/volunteer/tests/tests_view_Cycles.py
+++ b/source/apiVolontaria/volunteer/tests/tests_view_Cycles.py
@@ -29,6 +29,14 @@ class CyclesTests(APITestCase):
             ),
         )
 
+        self.past_cycle = Cycle.objects.create(
+            name='Cycle 2',
+            start_date=timezone.now() - timezone.timedelta(
+                days=10,
+            ),
+            end_date=timezone.now(),
+        )
+
     def test_create_new_cycle_with_permission(self):
         """
         Ensure we can create a new cycle if we have the permission.
@@ -83,6 +91,25 @@ class CyclesTests(APITestCase):
         start_date = self.cycle.start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         end_date = self.cycle.end_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
+        data = {
+            "id": self.cycle.id,
+            "name": self.cycle.name,
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(reverse('volunteer:cycles'))
+
+        self.assertEqual(json.loads(response.content)['results'][0], data)
+        self.assertEqual(json.loads(response.content)['count'], 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_list_cycle_when_is_active_true(self):
+        start_date = self.cycle.start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        end_date = self.cycle.end_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
         data = [
             {
                 "id": self.cycle.id,
@@ -94,8 +121,63 @@ class CyclesTests(APITestCase):
 
         self.client.force_authenticate(user=self.user)
 
-        response = self.client.get(reverse('volunteer:cycles'))
+        url = "{0}?is_active=True".format(
+            reverse('volunteer:cycles')
+        )
+
+        response = self.client.get(url)
 
         self.assertEqual(json.loads(response.content)['results'], data)
         self.assertEqual(json.loads(response.content)['count'], 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_list_cycle_when_is_active_false(self):
+        start_date = self.past_cycle.start_date\
+            .strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        end_date = self.past_cycle.end_date\
+            .strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        data = [
+            {
+                "id": self.past_cycle.id,
+                "name": self.past_cycle.name,
+                "start_date": start_date,
+                "end_date": end_date,
+            }
+        ]
+
+        self.client.force_authenticate(user=self.user)
+
+        url = "{0}?is_active=False".format(
+            reverse('volunteer:cycles')
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(json.loads(response.content)['count'], 1)
+        self.assertEqual(json.loads(response.content)['results'], data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_list_cycle_when_is_active_bad_input(self):
+        start_date = self.cycle.start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        end_date = self.cycle.end_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+        data = {
+            "id": self.cycle.id,
+            "name": self.cycle.name,
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+
+        self.client.force_authenticate(user=self.user)
+
+        # 'bad' is not a good input
+        url = "{0}?is_active=bad".format(
+            reverse('volunteer:cycles')
+        )
+
+        response = self.client.get(url)
+
+        self.assertEqual(json.loads(response.content)['results'][0], data)
+        self.assertEqual(json.loads(response.content)['count'], 2)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/source/apiVolontaria/volunteer/views.py
+++ b/source/apiVolontaria/volunteer/views.py
@@ -20,7 +20,17 @@ class Cycles(generics.ListCreateAPIView):
     serializer_class = serializers.CycleBasicSerializer
 
     def get_queryset(self):
-        return models.Cycle.objects.filter()
+        if 'is_active' in self.request.GET.keys():
+            is_active = self.request.GET.get('is_active')
+            if is_active in ['True', 'true']:
+                is_active = True
+            elif is_active in ['False', 'false']:
+                is_active = False
+            else:
+                is_active = None
+            return models.Cycle.objects.filter(is_active=is_active)
+        else:
+            return models.Cycle.objects.all()
 
     def post(self, request, *args, **kwargs):
         if self.request.user.has_perm('volunteer.add_cycle'):


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | #150 

---

##### What have you changed ?
Allow user to filter cycle by `is_active` property when list cycles with the API.

##### How did you change it ?
1. Add a custom manager to allow us filter by `is_active` property.
2. Update view to allow custom params property

##### Verification :

**PR standard**
 - [x] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [x] Fill in this automatically generated PR template
 - [x] Do not include issue numbers in the PR title
 - [x] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [x] This Pull-Request fully meets the requirements defined in the issue
 - [x] Add or modify the attached tests
 - [x] Follow the Python Styleguide
 - [x] Document new code based on the Documentation Styleguide
 - [x] Use I18N functions when you add some text
