### PR TITLE
fix django default permission name

### DIFF
--- a/source/apiVolontaria/location/views.py
+++ b/source/apiVolontaria/location/views.py
@@ -53,7 +53,7 @@ class AddressesId(generics.RetrieveUpdateDestroyAPIView):
         return Address.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('update_address'):
+        if self.request.user.has_perm('change_address'):
             try:
                 return self.partial_update(request, *args, **kwargs)
             except ValidationError as err:
@@ -115,7 +115,7 @@ class CountriesId(generics.RetrieveUpdateDestroyAPIView):
         return Country.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('update_country'):
+        if self.request.user.has_perm('change_country'):
             return self.partial_update(request, *args, **kwargs)
 
         content = {
@@ -174,7 +174,7 @@ class StateProvincesId(generics.RetrieveUpdateDestroyAPIView):
         return StateProvince.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('update_stateprovince'):
+        if self.request.user.has_perm('change_stateprovince'):
             return self.partial_update(request, *args, **kwargs)
 
         content = {

--- a/source/apiVolontaria/volunteer/views.py
+++ b/source/apiVolontaria/volunteer/views.py
@@ -59,7 +59,7 @@ class CyclesId(generics.RetrieveUpdateDestroyAPIView):
         return models.Cycle.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('volunteer.update_cycle'):
+        if self.request.user.has_perm('volunteer.change_cycle'):
             return self.partial_update(request, *args, **kwargs)
         else:
             content = {
@@ -127,7 +127,7 @@ class TaskTypesId(generics.RetrieveUpdateDestroyAPIView):
         return models.TaskType.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('volunteer.update_tasktype'):
+        if self.request.user.has_perm('volunteer.change_tasktype'):
             return self.partial_update(request, *args, **kwargs)
 
         content = {
@@ -195,7 +195,7 @@ class CellsId(generics.RetrieveUpdateDestroyAPIView):
         return models.Cell.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('volunteer.update_cell'):
+        if self.request.user.has_perm('volunteer.change_cell'):
             return self.partial_update(request, *args, **kwargs)
 
         content = {
@@ -278,7 +278,7 @@ class EventsId(generics.RetrieveUpdateDestroyAPIView):
         return models.Event.objects.filter()
 
     def patch(self, request, *args, **kwargs):
-        if self.request.user.has_perm('volunteer.update_event'):
+        if self.request.user.has_perm('volunteer.change_event'):
             return self.partial_update(request, *args, **kwargs)
 
         content = {


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | [#15](https://genielibre.com/issues/15) 

---

##### What have you changed ?
Correct name of django's default permissions used in view.

##### How did you change it ?
Just change the `name` hardcoded in each view.

##### Verification :

**PR standard**
 - [x] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [x] Fill in this automatically generated PR template
 - [x] Do not include issue numbers in the PR title
 - [x] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [x] This Pull-Request fully meets the requirements defined in the issue
 - [x] Add or modify the attached tests
 - [x] Follow the Python Styleguide
 - [x] Document new code based on the Documentation Styleguide
 - [x] Use I18N functions when you add some text