### PR TITLE
Enhancement edit presence participation fields

### DIFF
--- a/source/apiVolontaria/volunteer/permissions.py
+++ b/source/apiVolontaria/volunteer/permissions.py
@@ -15,4 +15,7 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
             return True
 
         # Write permissions are only allowed to the owner of the snippet.
-        return obj.user == request.user
+        if obj.user == request.user or request.user.is_superuser:
+            return True
+        else:
+            return False

--- a/source/apiVolontaria/volunteer/serializers.py
+++ b/source/apiVolontaria/volunteer/serializers.py
@@ -319,6 +319,36 @@ class ParticipationBasicSerializer(serializers.ModelSerializer):
             'user',
             'standby',
             'subscription_date',
+            'presence_duration_minutes',
+            'presence_status',
+        )
+        read_only_fields = [
+            'id',
+            'presence_duration_minutes',
+            'presence_status',
+        ]
+
+
+class ParticipationAdminSerializer(serializers.ModelSerializer):
+    """This class represents the Participation model serializer."""
+
+    # Explicitly declare the BooleanField to make it "required"
+    standby = serializers.BooleanField()
+    user = UserBasicSerializer(
+        read_only=True,
+        default=serializers.CurrentUserDefault(),
+    )
+
+    class Meta:
+        model = models.Participation
+        fields = (
+            'id',
+            'event',
+            'user',
+            'standby',
+            'subscription_date',
+            'presence_duration_minutes',
+            'presence_status',
         )
         read_only_fields = [
             'id',

--- a/source/apiVolontaria/volunteer/tests/tests_view_Participations.py
+++ b/source/apiVolontaria/volunteer/tests/tests_view_Participations.py
@@ -153,7 +153,15 @@ class ParticipationsTests(APITestCase):
         self.assertEqual(content['standby'], False)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'subscription_date', 'user', 'event', 'standby']
+        attributes = [
+            'id',
+            'subscription_date',
+            'user',
+            'event',
+            'standby',
+            'presence_duration_minutes',
+            'presence_status',
+        ]
 
         for key in content.keys():
             self.assertTrue(
@@ -216,7 +224,15 @@ class ParticipationsTests(APITestCase):
         self.assertEqual(content['count'], 3)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'user', 'event', 'subscription_date', 'standby']
+        attributes = [
+            'id',
+            'user',
+            'event',
+            'subscription_date',
+            'standby',
+            'presence_duration_minutes',
+            'presence_status',
+        ]
 
         for key in content['results'][0].keys():
             self.assertTrue(
@@ -255,7 +271,15 @@ class ParticipationsTests(APITestCase):
         self.assertEqual(content['results'][0]['id'], self.participation.id)
 
         # Check the system doesn't return attributes not expected
-        attributes = ['id', 'user', 'event', 'subscription_date', 'standby']
+        attributes = [
+            'id',
+            'user',
+            'event',
+            'subscription_date',
+            'standby',
+            'presence_duration_minutes',
+            'presence_status',
+        ]
 
         for key in content['results'][0].keys():
             self.assertTrue(

--- a/source/apiVolontaria/volunteer/views.py
+++ b/source/apiVolontaria/volunteer/views.py
@@ -354,6 +354,13 @@ class ParticipationsId(generics.RetrieveUpdateDestroyAPIView):
     def get_queryset(self):
         return models.Participation.objects.filter()
 
+    def get_serializer_class(self):
+        # If authenticated user is admin
+        if self.request.user.is_superuser:
+            return serializers.ParticipationAdminSerializer
+        else:
+            return serializers.ParticipationBasicSerializer
+
     def delete(self, request, *args, **kwargs):
         participation = self.get_object()
         if not participation.event.is_started:


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Enhancement
| Tickets (_issues_) concerned               | Fixed #173

---

##### What have you changed ?
 - Allow superuser to edit participations
 - Add new participation's fields in the API

##### How did you change it ?
1. Create a serializer for admin only
2. Change permission class to allow superuser to edit all participations
3. Update participation's serializer to display new fields

##### Verification :

**PR standard**
 - [x] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [x] Fill in this automatically generated PR template
 - [x] Do not include issue numbers in the PR title
 - [x] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [x] This Pull-Request fully meets the requirements defined in the issue
 - [x] Add or modify the attached tests
 - [x] Follow the Python Styleguide
 - [x] Document new code based on the Documentation Styleguide
 - [x] Use I18N functions when you add some text