### PR TITLE
replace 'detail' key by 'non_field_errors'

### DIFF
--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_ChangePassword.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_ChangePassword.py
@@ -77,7 +77,7 @@ class ChangePasswordTests(APITestCase):
         )
 
         content = {
-            'detail': "test is not a valid token.",
+            'non_field_errors': "test is not a valid token.",
         }
         self.assertEqual(json.loads(response.content), content)
 
@@ -230,7 +230,7 @@ class ChangePasswordTests(APITestCase):
         )
 
         content = {
-            'detail': [
+            'non_field_errors': [
                 'This password is too short. '
                 'It must contain at least 8 characters.',
             ],

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_ResetPassword.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_ResetPassword.py
@@ -169,7 +169,7 @@ class ResetPasswordTests(APITestCase):
         )
 
         content = {
-            'detail': "No account with this username.",
+            'non_field_errors': "No account with this username.",
         }
         self.assertEqual(json.loads(response.content), content)
 

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersActivation.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersActivation.py
@@ -75,7 +75,7 @@ class UsersActivationTests(APITestCase):
             format='json',
         )
 
-        content = {'detail': '"bad_token" is not a valid activation_token.'}
+        content = {'non_field_errors': '"bad_token" is not a valid activation_token.'}
         self.assertEqual(json.loads(response.content), content)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/source/apiVolontaria/apiVolontaria/views.py
+++ b/source/apiVolontaria/apiVolontaria/views.py
@@ -209,7 +209,7 @@ class UsersId(generics.RetrieveUpdateAPIView):
 
     def put(self, request, *args, **kwargs):
         content = {
-            "detail": _("Method \"PUT\" not allowed.")
+            'non_field_errors': _("Method \"PUT\" not allowed.")
         }
         return Response(content, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
@@ -254,7 +254,7 @@ class UsersActivation(APIView):
                 format(activation_token)
 
             return Response(
-                {'detail': error},
+                {'non_field_errors': error},
                 status=status.HTTP_400_BAD_REQUEST
             )
         # We have multiple token with the same key (impossible)
@@ -262,7 +262,7 @@ class UsersActivation(APIView):
             error = _("The system have a problem, please contact us, "
                       "it is not your fault.")
             return Response(
-                {'detail': error},
+                {'non_field_errors': error},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )
 
@@ -289,7 +289,7 @@ class ResetPassword(APIView):
             user = User.objects.get(username=request.data["username"])
         except Exception:
             content = {
-                'detail': _("No account with this username."),
+                'non_field_errors': _("No account with this username."),
             }
             return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
@@ -374,7 +374,7 @@ class ChangePassword(APIView):
                 password_validation.validate_password(password=new_password)
             except ValidationError as err:
                 content = {
-                    'detail': err,
+                    'non_field_errors': err,
                 }
                 return Response(content, status=status.HTTP_400_BAD_REQUEST)
 
@@ -394,7 +394,7 @@ class ChangePassword(APIView):
             error = '{0} is not a valid token.'.format(token)
 
             return Response(
-                {'detail': error},
+                {'non_field_errors': error},
                 status=status.HTTP_400_BAD_REQUEST
             )
 
@@ -403,6 +403,6 @@ class ChangePassword(APIView):
             error = _("The system has a problem, please contact us, "
                       "it is not your fault.")
             return Response(
-                {'detail': error},
+                {'non_field_errors': error},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )

--- a/source/apiVolontaria/volunteer/tests/tests_view_ParticipationsId.py
+++ b/source/apiVolontaria/volunteer/tests/tests_view_ParticipationsId.py
@@ -383,7 +383,7 @@ class ParticipationsIdTests(APITestCase):
         )
 
         content = {
-            'detail': "You can't delete a participation if the "
+            'non_field_errors': "You can't delete a participation if the "
                       "associated event is already started",
         }
 

--- a/source/apiVolontaria/volunteer/views.py
+++ b/source/apiVolontaria/volunteer/views.py
@@ -388,7 +388,7 @@ class ParticipationsId(generics.RetrieveUpdateDestroyAPIView):
             return self.destroy(request, *args, **kwargs)
         else:
             content = {
-                'detail': _("You can't delete a participation if the "
+                'non_field_errors': _("You can't delete a participation if the "
                             "associated event is already started"),
             }
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | Fix
| Tickets (_issues_) concerned               | None

---

##### What have you changed ?
Fix `detail` error key by `non_field_errors` key to be more generic and make frontend integration more easy.

##### How did you change it ?
Just change the custom error key in each custom error message.

##### Verification :

**PR standard**
 - [x] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [x] Fill in this automatically generated PR template
 - [x] Do not include issue numbers in the PR title
 - [x] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [x] This Pull-Request fully meets the requirements defined in the issue
 - [x] Add or modify the attached tests
 - [x] Follow the Python Styleguide
 - [x] Document new code based on the Documentation Styleguide
 - [x] Use I18N functions when you add some text