### PR TITLE
Add the possibility to set a custom user when adding a Participation

### DIFF
--- a/source/apiVolontaria/volunteer/fields.py
+++ b/source/apiVolontaria/volunteer/fields.py
@@ -1,0 +1,22 @@
+from rest_framework.compat import unicode_to_repr
+
+
+class CustomOrCurrentUserIdDefault(object):
+    def set_context(self, serializer_field):
+
+        self.user_id = None
+        # Get the received user id if it exist in request data
+        user_id = serializer_field.context['request'].data.get('user', None)
+
+        if user_id:
+            self.user_id = user_id
+
+        if not self.user_id:
+            # Set the user to currently logged user
+            self.user_id = serializer_field.context['request'].user.id
+
+    def __call__(self):
+        return self.user_id
+
+    def __repr__(self):
+        return unicode_to_repr('%s()' % self.__class__.__name__)

--- a/source/apiVolontaria/volunteer/permissions.py
+++ b/source/apiVolontaria/volunteer/permissions.py
@@ -1,6 +1,8 @@
 from rest_framework import permissions
 from rest_framework.permissions import DjangoModelPermissions
 
+from volunteer.models import Event
+
 
 class EventIsManager(permissions.BasePermission):
     """
@@ -25,15 +27,37 @@ class ParticipationIsManager(permissions.BasePermission):
 
     @staticmethod
     def if_can_do_actions(request, view, obj):
-        is_owner = obj.user == request.user
-        is_manager = request.user in obj.event.cell.managers.all()
-
         dj_perm = DjangoModelPermissions()
-        is_django_perms = dj_perm.has_object_permission(
-            request, view, obj
-        )
 
-        return is_owner or (is_manager and is_django_perms) or request.user.is_superuser
+        # We receive and obj so we are updating
+        if obj:
+            is_owner = obj.user == request.user
+            is_manager = request.user in obj.event.cell.managers.all()
+
+            is_django_perms = dj_perm.has_object_permission(
+                request, view, obj
+            )
+        # We don't receive an object, we are creating
+        else:
+            is_owner = False
+            is_manager = False
+
+            # Need to get the event of the request to validates permissions
+            event = None
+            event_id = request.data.get('event', None)
+
+            if event_id:
+                event = Event.objects.filter(pk=event_id).first()
+                if event:
+                    is_manager = request.user in event.cell.managers.all()
+
+            is_django_perms = dj_perm.has_permission(
+                request, view
+            )
+
+        return is_owner or \
+            (is_manager and is_django_perms) or \
+            request.user.is_superuser
 
     def has_object_permission(self, request, view, obj):
         # Read permissions are allowed to any request,


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Features]
| Tickets (_issues_) concerned               | [[137](https://genielibre.com/issues/137)]

---

##### What have you changed ?
Added the option to add a Participation with a custom user for the cell manager.



##### Verification :

**PR standard**
 - [X] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [X] Fill in this automatically generated PR template
 - [X] Do not include issue numbers in the PR title
 - [X] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [X] This Pull-Request fully meets the requirements defined in the issue
 - [X] Add or modify the attached tests
 - [X] Follow the Python Styleguide
 - [X] Document new code based on the Documentation Styleguide
 - [X] Use I18N functions when you add some text