### PR TITLE
Fix 'view user' permission for cells managers

### DIFF
--- a/source/apiVolontaria/apiVolontaria/views.py
+++ b/source/apiVolontaria/apiVolontaria/views.py
@@ -100,7 +100,7 @@ class Users(generics.ListCreateAPIView):
         return User.objects.all()
 
     def get(self, request, *args, **kwargs):
-        if self.request.user.has_perm('apiVolontaria.list_user'):
+        if self.request.user.has_perm('auth.view_user'):
             return self.list(request, *args, **kwargs)
 
         content = {

--- a/source/apiVolontaria/volunteer/models.py
+++ b/source/apiVolontaria/volunteer/models.py
@@ -188,6 +188,9 @@ def set_permission_cell_manager(user, add=True):
     permission_delete_event = Permission.objects \
         .get(name='Can delete event')
 
+    permission_view_user = Permission.objects \
+        .get(name='Can view user')
+
     if add:
         user.user_permissions.add(permission_add_participation)
         user.user_permissions.add(permission_update_participation)
@@ -195,6 +198,7 @@ def set_permission_cell_manager(user, add=True):
         user.user_permissions.add(permission_add_event)
         user.user_permissions.add(permission_update_event)
         user.user_permissions.add(permission_delete_event)
+        user.user_permissions.add(permission_view_user)
     else:
         user.user_permissions.remove(permission_add_participation)
         user.user_permissions.remove(permission_update_participation)
@@ -202,6 +206,7 @@ def set_permission_cell_manager(user, add=True):
         user.user_permissions.remove(permission_add_event)
         user.user_permissions.remove(permission_update_event)
         user.user_permissions.remove(permission_delete_event)
+        user.user_permissions.remove(permission_view_user)
 
     user.save()
 


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Enhancement]
| Tickets (_issues_) concerned               | [[214](https://genielibre.com/issues/214)]

---

##### What have you changed ?
Added the view user permission for the cell manager


##### Verification :

**PR standard**
 - [X] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [X] Fill in this automatically generated PR template
 - [X] Do not include issue numbers in the PR title
 - [X] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [X] This Pull-Request fully meets the requirements defined in the issue
 - [X] Add or modify the attached tests
 - [X] Follow the Python Styleguide
 - [X] Document new code based on the Documentation Styleguide
 - [X] Use I18N functions when you add some text