### PR TITLE
Replace the 500 screen by form errors when creating an Event from Dja…

### DIFF
--- a/source/apiVolontaria/volunteer/admin.py
+++ b/source/apiVolontaria/volunteer/admin.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
 
 from volunteer.resources import ParticipationResource
-from . import models
+from . import models, forms
 from apiVolontaria.models import Profile
 
 
@@ -76,6 +76,7 @@ class ParticipationAdmin(ImportExportActionModelAdmin):
 
 
 class EventAdmin(admin.ModelAdmin):
+    form = forms.EventAdminForm
     list_display = [
         'task_type',
         'cell',

--- a/source/apiVolontaria/volunteer/forms.py
+++ b/source/apiVolontaria/volunteer/forms.py
@@ -1,0 +1,41 @@
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from . import models
+
+
+class EventAdminForm(forms.ModelForm):
+    class Meta:
+        model = models.Event
+        fields = '__all__'
+
+    def clean(self):
+        start_date = self.cleaned_data['start_date']
+        end_date = self.cleaned_data['end_date']
+
+        if start_date and end_date:
+
+            if start_date > end_date:
+                error = _("The start date needs to be older than end date.")
+                raise forms.ValidationError({
+                    'start_date': error,
+                    'end_date': error,
+                })
+
+            try:
+                cycle = self.cleaned_data['cycle']
+            except:
+                cycle = None
+
+            if cycle:
+                if cycle.start_date and cycle.start_date > start_date:
+                    error = _("The start date can't be older than "
+                              "start date of the cycle.")
+                    raise forms.ValidationError({'start_date': error})
+
+                if cycle.end_date and cycle.end_date < end_date:
+                    error = _("The end date can't be younger than "
+                              "end date of the cycle.")
+                    raise forms.ValidationError({'end_date': error})
+
+        return self.cleaned_data

--- a/source/apiVolontaria/volunteer/tests/tests_admin_EventAdmin.py
+++ b/source/apiVolontaria/volunteer/tests/tests_admin_EventAdmin.py
@@ -1,3 +1,4 @@
+import datetime
 from django.contrib.auth.models import User
 from rest_framework.test import APITransactionTestCase
 
@@ -5,8 +6,10 @@ from django.contrib.admin.sites import AdminSite
 from django.test import Client
 
 from apiVolontaria.models import Profile
+from location.models import Address, StateProvince, Country
+from volunteer.forms import EventAdminForm
 from ..admin import EventAdmin
-from ..models import Event
+from ..models import Event, Cycle, Cell, TaskType
 
 
 class EventAdminTests(APITransactionTestCase):
@@ -16,6 +19,37 @@ class EventAdminTests(APITransactionTestCase):
 
         self.site = AdminSite()
         self.admin = EventAdmin(Event, self.site)
+
+        self.random_country = Country.objects.create(
+            name="random country",
+            iso_code="RC",
+        )
+        self.random_state_province = StateProvince.objects.create(
+            name="random state",
+            iso_code="RS",
+            country=self.random_country,
+        )
+        self.address = Address.objects.create(
+            address_line1='random address 1',
+            postal_code='RAN DOM',
+            city='random city',
+            state_province=self.random_state_province,
+            country=self.random_country,
+        )
+        self.cell = Cell.objects.create(
+            name="my cell",
+            address=self.address,
+        )
+
+        self.task_type = TaskType.objects.create(
+            name="my tasktype",
+        )
+
+        self.cycle = Cycle.objects.create(
+            name="my cycle",
+            start_date=datetime.datetime(2018, 11, 15, 00, 00, 00),
+            end_date=datetime.datetime(2018, 11, 17, 00, 00, 00),
+        )
 
     def create_user(self):
         self.username = "test_admin"
@@ -52,3 +86,82 @@ class EventAdminTests(APITransactionTestCase):
 
     def test_admin_events(self):
         self.assertNotEqual(self.admin, None)
+
+    def test_admin_form_dates(self):
+        data_wrong_start_end_date = {
+            'start_date': datetime.datetime(2018, 11, 23, 00, 00, 00),
+            'end_date': datetime.datetime(2018, 11, 22, 00, 00, 00)
+        }
+        form = EventAdminForm(data_wrong_start_end_date)
+
+        form.is_valid()
+
+        self.assertEqual(form.errors['start_date'], ['The start date needs to be older than end date.'])
+        self.assertEqual(form.errors['end_date'], ['The start date needs to be older than end date.'])
+
+        data_start_time_outside_cycle_time = {
+            'start_date': datetime.datetime(2018, 11, 14, 00, 00, 00),
+            'end_date': datetime.datetime(2018, 11, 18, 00, 00, 00),
+            'nb_volunteers_needed': 1,
+            'nb_volunteers_standby_needed': 1,
+            'cell': self.cell.pk,
+            'cycle': self.cycle.pk,
+            'task_type': self.task_type.pk,
+
+        }
+        form = EventAdminForm(data_start_time_outside_cycle_time)
+
+        form.is_valid()
+
+        self.assertEqual(
+            form.errors['start_date'],
+            ["The start date can't be older than start date of the cycle."])
+
+        data_end_time_outside_cycle_time = {
+            'start_date': datetime.datetime(2018, 11, 16, 00, 00, 00),
+            'end_date': datetime.datetime(2018, 11, 18, 00, 00, 00),
+            'nb_volunteers_needed': 1,
+            'nb_volunteers_standby_needed': 1,
+            'cell': self.cell.pk,
+            'cycle': self.cycle.pk,
+            'task_type': self.task_type.pk,
+
+        }
+        form = EventAdminForm(data_end_time_outside_cycle_time)
+
+        form.is_valid()
+
+        self.assertEqual(
+            form.errors['end_date'],
+            ["The end date can't be younger than end date of the cycle."])
+
+        data_no_cycle = {
+            'start_date': datetime.datetime(2018, 11, 16, 2, 00, 00),
+            'end_date': datetime.datetime(2018, 11, 16, 4, 00, 00),
+            'nb_volunteers_needed': 1,
+            'nb_volunteers_standby_needed': 1,
+            'cell': self.cell.pk,
+            'task_type': self.task_type.pk,
+
+        }
+        form = EventAdminForm(data_no_cycle)
+
+        form.is_valid()
+
+        self.assertEqual(
+            form.errors['cycle'],
+            ["This field is required."])
+
+        data_good = {
+            'start_date': datetime.datetime(2018, 11, 16, 2, 00, 00),
+            'end_date': datetime.datetime(2018, 11, 16, 4, 00, 00),
+            'nb_volunteers_needed': 1,
+            'nb_volunteers_standby_needed': 1,
+            'cell': self.cell.pk,
+            'cycle': self.cycle.pk,
+            'task_type': self.task_type.pk,
+
+        }
+        form = EventAdminForm(data_good)
+
+        self.assertTrue(form.is_valid())


### PR DESCRIPTION
…ngo Admin

| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Enhancement]
| Tickets (_issues_) concerned               | [[61](https://genielibre.com/issues/61)]

---

##### What have you changed ?
Added a form with clen function for the Event admin to show the proper error instead of a HTTP 500 status

##### Verification :

**PR standard**
 - [X] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [X] Fill in this automatically generated PR template
 - [X] Do not include issue numbers in the PR title
 - [X] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [X] This Pull-Request fully meets the requirements defined in the issue
 - [X] Add or modify the attached tests
 - [X] Follow the Python Styleguide
 - [X] Document new code based on the Documentation Styleguide
 - [X] Use I18N functions when you add some text