### PR TITLE
[WIP] Add a last_participation field to the Participation Serializer

### DIFF
--- a/source/apiVolontaria/apiVolontaria/serializers.py
+++ b/source/apiVolontaria/apiVolontaria/serializers.py
@@ -9,6 +9,8 @@ from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import authenticate, password_validation
 
 from volunteer.models import Cell
+
+from volunteer.models import Participation
 from .models import ActionToken, Profile
 
 
@@ -205,6 +207,48 @@ class UserBasicSerializer(serializers.ModelSerializer):
             UserBasicSerializer,
             self
         ).update(instance, validated_data)
+
+
+class UserAdminSerializer(UserBasicSerializer):
+    class Meta:
+        model = User
+        fields = (
+            'id',
+            'username',
+            'email',
+            'first_name',
+            'last_name',
+            'is_active',
+            'is_superuser',
+            'password',
+            'new_password',
+            'phone',
+            'mobile',
+            'managed_cell',
+            'last_participation'
+        )
+        write_only_fields = (
+            'password',
+            'new_password',
+        )
+        read_only_fields = (
+            'is_staff',
+            'is_superuser',
+            'is_active',
+            'date_joined',
+            'last_participation'
+        )
+
+    last_participation = serializers.SerializerMethodField()
+
+    def get_last_participation(self, obj):
+        last_participation = \
+            Participation.objects.filter(user=obj, presence_status='P').order_by('-event__start_date').first()
+
+        if last_participation:
+            return last_participation.start_date
+
+        return ''
 
 
 class UserPublicSerializer(serializers.ModelSerializer):

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_Users.py
@@ -551,6 +551,7 @@ class UsersTests(APITestCase):
             'mobile',
             'is_superuser',
             'managed_cell',
+            'last_participation',
         ]
         for key in first_user.keys():
             self.assertTrue(

--- a/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
+++ b/source/apiVolontaria/apiVolontaria/tests/tests_view_UsersId.py
@@ -91,6 +91,7 @@ class UsersIdTests(APITestCase):
             'mobile',
             'is_superuser',
             'managed_cell',
+            'last_participation',
         ]
         for key in content.keys():
             self.assertTrue(
@@ -198,6 +199,7 @@ class UsersIdTests(APITestCase):
             'mobile',
             'is_superuser',
             'managed_cell',
+            'last_participation',
         ]
         for key in content.keys():
             self.assertTrue(

--- a/source/apiVolontaria/apiVolontaria/views.py
+++ b/source/apiVolontaria/apiVolontaria/views.py
@@ -1,4 +1,3 @@
-from django.db.models import Q
 from django.core.exceptions import ValidationError
 from django.contrib.auth import authenticate, password_validation
 from django.contrib.auth.models import User
@@ -12,6 +11,7 @@ from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from volunteer.models import Cell
 from . import serializers
 from .models import TemporaryToken, ActionToken
 from django.template.loader import render_to_string
@@ -98,6 +98,14 @@ class Users(generics.ListCreateAPIView):
     serializer_class = serializers.UserBasicSerializer
     filter_backends = (filters.SearchFilter,)
     search_fields = ('username', 'first_name', 'last_name', 'email')
+
+    def get_serializer_class(self):
+        # Need to know if we are in admin section or in user profile
+
+        if self.request.user and (self.request.user.is_superuser or Cell.objects.filter(managers__in=[self.request.user.id]).count()):
+            return serializers.UserAdminSerializer
+
+        return serializers.UserBasicSerializer
 
     def get_queryset(self):
         return User.objects.all()
@@ -191,6 +199,14 @@ class UsersId(generics.RetrieveUpdateAPIView):
     Partially update a user.
     """
     serializer_class = serializers.UserBasicSerializer
+
+    def get_serializer_class(self):
+        # Need to know if we are in admin section or in user profile
+        if 'profile' not in self.kwargs.keys() and \
+                (self.request.user.is_superuser or Cell.objects.filter(managers__in=[self.request.user]).count()):
+            return serializers.UserAdminSerializer
+
+        return serializers.UserBasicSerializer
 
     def get_queryset(self):
         return User.objects.filter()

--- a/source/apiVolontaria/volunteer/permissions.py
+++ b/source/apiVolontaria/volunteer/permissions.py
@@ -1,6 +1,8 @@
 from rest_framework import permissions
 from rest_framework.permissions import DjangoModelPermissions
 
+from volunteer.models import Event
+
 
 class EventIsManager(permissions.BasePermission):
     """
@@ -25,15 +27,36 @@ class ParticipationIsManager(permissions.BasePermission):
 
     @staticmethod
     def if_can_do_actions(request, view, obj):
-        is_owner = obj.user == request.user
-        is_manager = request.user in obj.event.cell.managers.all()
-
         dj_perm = DjangoModelPermissions()
-        is_django_perms = dj_perm.has_object_permission(
-            request, view, obj
-        )
 
-        return is_owner or (is_manager and is_django_perms) or request.user.is_superuser
+        # We receive and obj so we are updating
+        if obj:
+            is_owner = obj.user == request.user
+            is_manager = request.user in obj.event.cell.managers.all()
+
+            is_django_perms = dj_perm.has_object_permission(
+                request, view, obj
+            )
+        # We don't receive an object, we are creating
+        else:
+            is_owner = False
+            is_manager = False
+
+            # Need to get the event of the request to validates permissions
+            event_id = request.data.get('event', None)
+
+            if event_id:
+                event = Event.objects.filter(pk=event_id).first()
+                if event:
+                    is_manager = request.user in event.cell.managers.all()
+
+            is_django_perms = dj_perm.has_permission(
+                request, view
+            )
+
+        return is_owner or \
+            (is_manager and is_django_perms) or \
+            request.user.is_superuser
 
     def has_object_permission(self, request, view, obj):
         # Read permissions are allowed to any request,

--- a/source/apiVolontaria/volunteer/serializers.py
+++ b/source/apiVolontaria/volunteer/serializers.py
@@ -12,7 +12,7 @@ from django.utils import timezone
 from location.serializers import AddressBasicSerializer
 from location.models import Address, StateProvince, Country
 
-from apiVolontaria.serializers import UserPublicSerializer, UserBasicSerializer
+from apiVolontaria.serializers import UserPublicSerializer, UserBasicSerializer, UserAdminSerializer
 from django.contrib.auth.models import User
 
 from . import models
@@ -456,7 +456,7 @@ class ParticipationAdminSerializer(serializers.ModelSerializer):
 
     # Explicitly declare the BooleanField to make it "required"
     standby = serializers.BooleanField()
-    user = UserBasicSerializer(
+    user = UserAdminSerializer(
         read_only=True,
         default=serializers.CurrentUserDefault(),
     )

--- a/source/apiVolontaria/volunteer/tests/tests_view_ParticipationsId.py
+++ b/source/apiVolontaria/volunteer/tests/tests_view_ParticipationsId.py
@@ -434,7 +434,8 @@ class ParticipationsIdTests(APITestCase):
                 "is_superuser": self.user2.is_superuser,
                 "phone": None,
                 "mobile": None,
-                "managed_cell": []
+                "managed_cell": [],
+                "last_participation": self.participation.event.start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
             },
             "standby": True,
             "subscription_date": subscription_date_str,


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Enhancement]
| Tickets (_issues_) concerned               | [[250]](https://genielibre.com/issues/250)

---

Require the merge of API-Volontaria: [225](https://github.com/Volontaria/API-Volontaria/pull/225/)

##### What have you changed ?
Add a last_participation field to the Participation Serializer and split into ParticipationBasicSerializer and ParticipationAdminSerializer to show or not this field

##### Verification :

**PR standard**
 - [X] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [X] Fill in this automatically generated PR template
 - [X] Do not include issue numbers in the PR title
 - [X] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [X] This Pull-Request fully meets the requirements defined in the issue
 - [X] Add or modify the attached tests
 - [X] Follow the Python Styleguide
 - [X] Document new code based on the Documentation Styleguide
 - [X] Use I18N functions when you add some text