### PR TITLE
Reset password can nom be done using username or email

### DIFF
--- a/source/apiVolontaria/apiVolontaria/serializers.py
+++ b/source/apiVolontaria/apiVolontaria/serializers.py
@@ -8,7 +8,6 @@ from django.contrib.auth.models import User
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth import authenticate, password_validation
 
-from django.core import exceptions
 from volunteer.models import Cell
 from .models import ActionToken, Profile
 
@@ -230,7 +229,7 @@ class UserPublicSerializer(serializers.ModelSerializer):
 
 class ResetPasswordSerializer(serializers.Serializer):
 
-    username = serializers.CharField(required=True)
+    username_email = serializers.CharField(required=True)
 
 
 class ChangePasswordSerializer(serializers.Serializer):

--- a/source/apiVolontaria/apiVolontaria/views.py
+++ b/source/apiVolontaria/apiVolontaria/views.py
@@ -298,19 +298,23 @@ class ResetPassword(APIView):
         # Valid params
         serializer = serializers.ResetPasswordSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        text_error_not_email_send =  {
+        text_error_not_email_send = {
                     'detail': _("Your token has been created but no email "
                                 "has been sent. Please contact the "
                                 "administration."),
                 }
 
-        # get user from the username given in data
+        # get user from the username or email given in data
         try:
-            user = User.objects.get(username=request.data["username"])
+            user = User.objects.filter(username=request.data["username_email"]).first()
+
+            if not user:
+                user = User.objects.get(email=request.data["username_email"])
+
         except Exception:
             content = {
-                'username': [
-                    _("No account with this username.")
+                'username_email': [
+                    _("No account with this username or email.")
                 ],
             }
             return Response(content, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
| Q                                                      | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                      | [Enhancement]
| Tickets (_issues_) concerned               | [[251]](https://genielibre.com/issues/251)

---

##### What have you changed ?
Add the possibility to reset a loast password using username or email

##### Verification :

**PR standard**
 - [X] Branches naming convention: 
     - `prefix-snake_case_description`
     - ex: `enhancement-create_new_cell`
     - ex: `fix-pep8_standard_on_cell_model`
 - [X] Fill in this automatically generated PR template
 - [X] Do not include issue numbers in the PR title
 - [X] Include screenshots and animated GIFs in your pull request whenever possible

**Code standard**
 - [X] This Pull-Request fully meets the requirements defined in the issue
 - [X] Add or modify the attached tests
 - [X] Follow the Python Styleguide
 - [X] Document new code based on the Documentation Styleguide
 - [X] Use I18N functions when you add some text