### PR TITLE
Upgraded djmoney from 1.1 to 2.0.1 version in requirements.txt

### DIFF
--- a/api_volontaria/apps/user/tests/test_view_users.py
+++ b/api_volontaria/apps/user/tests/test_view_users.py
@@ -69,6 +69,7 @@ class UsersTests(CustomAPITestCase):
             'event': {
                 'create': False,
                 'update': False,
+                'read': True,
                 'destroy': False,
             },
             'participation': {

--- a/api_volontaria/apps/volunteer/admin.py
+++ b/api_volontaria/apps/volunteer/admin.py
@@ -111,6 +111,12 @@ class EventAdmin(admin.ModelAdmin):
     date_hierarchy = 'start_time'
     ordering = ('start_time',)
 
+    search_fields = [
+        'description', 'start_time', 
+        'cell__name', 
+        'task_type__name', 
+    ]
+
     @staticmethod
     def status_volunteers(obj):
         return str(obj.nb_volunteers) + ' / ' + \

--- a/api_volontaria/apps/volunteer/models.py
+++ b/api_volontaria/apps/volunteer/models.py
@@ -205,6 +205,12 @@ class Event(models.Model):
         on_delete=models.PROTECT,
     )
 
+    search_fields = ['description', 
+                    'start_time',
+                    'cell__name',
+                    'task_type__name',
+                    ]
+
     def __str__(self):
         return str(self.start_time) + ' - ' + str(self.end_time)
 
@@ -238,6 +244,14 @@ class Event(models.Model):
     def has_list_permission(request):
         return True
 
+    @staticmethod
+    def has_read_permission(request):
+        return True
+
+    @staticmethod
+    def has_object_read_permission(request):
+        return True
+   
     @staticmethod
     @authenticated_users
     def has_create_permission(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ jsonfield==3.1.0
 django-model-utils==4.0.0
 babel==2.8.0
 django-import-export==2.0.2
-django-money==1.1
+django-money==2.0.1
 
 # Documentation tools
 mkdocs==1.1.2


### PR DESCRIPTION
| Q                                          | R
| ------------------------------------------ | -------------------------------------------
| Type of contribution ?                     | Fix + Improvement
| Tickets (_issues_) concerned               | non applicable

---

##### What have you changed ?
- Upgraded djmoney to current version
- Added a search field to event model, in order to allow filtering in Angular Front End
- Added read and object read permission for any user, so that non-authenticated users may view the details of an event

##### How did you change it ?
- Edited requirements.txt
- Edited event model
- Edited event model permission in user test file

##### Is there a special consideration?
None 
(FYI: current 1.1 version breaks and returns an error message
web_1            |   File "/code/api_volontaria/apps/position/models.py", line 12, in <module>
web_1            |     from djmoney.models.fields import MoneyField
web_1            |   File "/usr/local/lib/python3.8/site-packages/djmoney/models/fields.py", line 12, in <module>
web_1            |     from djmoney import forms
web_1            |   File "/usr/local/lib/python3.8/site-packages/djmoney/forms/__init__.py", line 1, in <module>
web_1            |     from .fields import *  # noqa
web_1            |   File "/usr/local/lib/python3.8/site-packages/djmoney/forms/fields.py", line 4, in <module>
web_1            |     from djmoney.money import Money
web_1            |   File "/usr/local/lib/python3.8/site-packages/djmoney/money.py", line 9, in <module>
web_1            |     from moneyed.localization import _FORMATTER, format_money
web_1            | ModuleNotFoundError: No module named 'moneyed.localization')

Upgrading to 2.0.1 fixes the error. Tests run with no error.

Verification :
 -  [ x] My branch name respect the standard defined in `CONTRIBUTING.md`
 -  [ x] All my commits respect the standard defined in `CONTRIBUTING.md`
 -  [ x] This Pull-Request fully meets the requirements defined in the issue
 -  [ ] I added or modified the attached tests
 -  [ ] I added or modified the documentation