### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/api_volontaria/apps/user/tests/test_api_token.py
+++ b/api_volontaria/apps/user/tests/test_api_token.py
@@ -187,7 +187,7 @@ class APITokenTests(CustomAPITestCase):
             initial_api_token_count + 1
         )
     
-    def test_user_cannot_create_api_token(self):
+    def test_user_cannot_create_api_token_two(self):
 
         self.client.force_authenticate(user=self.user)       
 


### PR DESCRIPTION
Fixes #306.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

